### PR TITLE
Set spawn mode on multiprocessing simulator

### DIFF
--- a/min_max_engine/mmEngine/value_funtions/nn_keras.py
+++ b/min_max_engine/mmEngine/value_funtions/nn_keras.py
@@ -4,6 +4,7 @@ import tensorflow as tf # type: ignore
 from mmEngine.value_funtions.value_function import ValueFunction  # type: ignore
 import tensorflow.keras as keras  # type: ignore
 import tensorflow.keras.layers as layers  # type: ignore
+import tensorflow.keras.backend as K # type: ignore
 import numpy as np
 from typing import Optional
 from pathlib import Path


### PR DESCRIPTION
* This allows tensorflow to start in all the processes instead of
  crashing.
* Tensorflow does not succeed in allocating the memory, I have no idea
  why. Further investigatoin is needed.